### PR TITLE
fix: jsx 태그에서 class 속성을 className 으로 변경

### DIFF
--- a/src/Movie.js
+++ b/src/Movie.js
@@ -4,11 +4,11 @@ import "./Movie.css";
 
 function Movie({year, title, summary, poster, genres}){
     return (
-        <div class="movie">
+        <div className="movie">
             <img src={poster} alt={title} title={title} />
-            <div class="movie__data">
-                <h3 class="movie__title">{title}</h3>
-                <h5 class="movie__year">{year}</h5>
+            <div className="movie__data">
+                <h3 className="movie__title">{title}</h3>
+                <h5 className="movie__year">{year}</h5>
                 <ul className="movie__genres">
                     {genres.map((genre, index) => 
                     <li key={index} className="genres__genre">
@@ -16,7 +16,7 @@ function Movie({year, title, summary, poster, genres}){
                     </li>
                     )}
                     </ul>
-                <p class="movie__summary">{summary.slice(0, 180)}...</p>
+                <p className="movie__summary">{summary.slice(0, 180)}...</p>
             </div>
         </div>
     );


### PR DESCRIPTION
HTML 파일이면 class 가 맞는데,
이건 JSX 파일이고 바벨이라는 JS 문법을 읽어서 HTML 요소 생성 함수로 만들어주는 도구가 class 라는 표현을 중복적으로 받아들일 수 있어서(예약어)
className 이라고 써야 해요.